### PR TITLE
Update runtime from Node 14 to Node 20

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/package-name/package.json
+++ b/packages/package-name/package.json
@@ -7,7 +7,7 @@
   "author": "Drew Keller <drew@wimpyprogrammer.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=14"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsc -b --clean && tsc -b",


### PR DESCRIPTION
Update runtime from Node 14 to Node 20.  Node 14 reached EOL on April 30, 2023.